### PR TITLE
Fix GError handling in library binding source and simple example.

### DIFF
--- a/System/Libnotify.hsc
+++ b/System/Libnotify.hsc
@@ -197,7 +197,7 @@ showNotify notify =
     then return result
     else do error <- peek p_error
             g_error_free p_error
-            throw error
+            throwGError error
 
 foreign import ccall unsafe "libnotify/notify.h notify_notification_show"
   notify_notification_show :: Notification -> Ptr (Ptr GError) -> IO Bool
@@ -396,7 +396,7 @@ closeNotify notify =
     then return result
     else do error <- peek p_error
             g_error_free p_error
-            throw error
+            throwGError error
 
 foreign import ccall unsafe "libnotify/notify.h notify_notification_close"
   notify_notification_close :: Notification -> Ptr (Ptr GError) -> IO Bool

--- a/example/Simple.hs
+++ b/example/Simple.hs
@@ -16,13 +16,13 @@ new message = do
   return notify
 
 open n = do
-  catchGError (showNotify n) $ \error -> do
-    putStrLn $ "show: " ++ show error
+  catchGError (showNotify n) $ \(GError dom code msg) -> do
+    putStr "show: " >> print (dom, code, msg)
     return False
 
 close n = do
-  catchGError (closeNotify n) $ \error -> do
-    putStrLn $ "show: " ++ show error
+  catchGError (closeNotify n) $ \(GError dom code msg) -> do
+    putStr "show: " >> print (dom, code, msg)
     return False
 
 loop count lastNotify = do


### PR DESCRIPTION
According to [docs](http://hackage.haskell.org/packages/archive/glib/0.12.0/doc/html/src/System-Glib-GError.html#GError) `GError` is not an instance of `Exception` typeclass nor `Show` so some workaround is needed.
Cannot make fix for mpd example that I'll be certain about though, because I don't have Network.MPD on this machine.
